### PR TITLE
fix: list available versions of go-jira in one line

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -14,4 +14,4 @@ function sort_versions() {
 }
 
 # Fetch all tag names
-eval "$cmd" | grep 'tag_name' | cut -d '"' -f 4 | sed -e 's/^v//' | sort_versions
+eval "$cmd" | grep 'tag_name' | cut -d '"' -f 4 | sed -e 's/^v//' | sort_versions | paste -sd ' ' -


### PR DESCRIPTION
Hi there,

I've had a problem with asdf-vm only displaying the first release of go-jira when running `asdf list-all go-jira`, whereas directly invoking bin/list-all produced all available versions in the correct order (see logs below).

I'm not entirely sure if this is a breaking change in asdf-vm or if something is wrong with my system (I'm on Fedora 34) but the tests are passing and everything works as expected on my end now. Would appreciate if you could look into merging this despite my uncertainty of what exactly the problem is.. :sweat_smile: 

Cheers

```shell_session
# before the change

$ asdf list-all go-jira
0.1.14

$ ./bin/list-all
0.1.14
0.1.15
[...]
1.0.26
1.0.27

# after the change

$ asdf list-all go-jira
0.1.14
0.1.15
[...]
1.0.26
1.0.27

$ ./bin/list-all
0.1.14 0.1.15 1.0.0 1.0.1 1.0.2 1.0.3 1.0.4 1.0.5 1.0.6 1.0.7 1.0.8 1.0.9 1.0.10 1.0.11 1.0.12 1.0.13 1.0.14 1.0.15 1.0.16 1.0.17 1.0.18 1.0.19 1.0.20 1.0.21 1.0.22 1.0.23 1.0.24 1.0.25 1.0.26 1.0.27
```
Test workflow results: https://github.com/itspngu/asdf-go-jira/actions/runs/931027364